### PR TITLE
margaux/artwork-on-answer

### DIFF
--- a/app/src/androidTest/java/ch/sdp/vibester/activity/BuzzerScreenActivityTest.kt
+++ b/app/src/androidTest/java/ch/sdp/vibester/activity/BuzzerScreenActivityTest.kt
@@ -83,7 +83,7 @@ class BuzzerScreenActivityTest {
     }
 
     @Test
-    fun answerIsPresentButGoneOnStartup() {
+    fun answerIsPresentButInvisibleOnStartup() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), BuzzerScreenActivity::class.java)
 
         // Put mock extras inside

--- a/app/src/main/java/ch/sdp/vibester/activity/BuzzerScreenActivity.kt
+++ b/app/src/main/java/ch/sdp/vibester/activity/BuzzerScreenActivity.kt
@@ -22,7 +22,7 @@ import kotlin.collections.HashMap
 class BuzzerScreenActivity : GameActivity() {
 
     private val MAX_N_PLAYERS = 4
-    private val artwork_dim = 300
+    private val artwork_dim = 200
     private val NO_BUZZER_PRESSED = -1
     private val buzzersToRows:HashMap<Int, Int> = initHashmap()
     private val rowsIdArray = ArrayList(buzzersToRows.values)
@@ -117,8 +117,6 @@ class BuzzerScreenActivity : GameActivity() {
     private fun startRound(ctx: Context, gameManager: BuzzerGameManager) {
         gameIsOn = true
         findViewById<LinearLayout>(R.id.answer).visibility=View.INVISIBLE
-
-        // fetch song and initialise answerText. We'll see later for the image
         val title = gameManager.getCurrentSong().getTrackName()
         val artist = gameManager.getCurrentSong().getArtistName()
         findViewById<TextView>(R.id.songTitle).text= "$title - $artist"

--- a/app/src/main/java/ch/sdp/vibester/activity/BuzzerScreenActivity.kt
+++ b/app/src/main/java/ch/sdp/vibester/activity/BuzzerScreenActivity.kt
@@ -1,6 +1,5 @@
 package ch.sdp.vibester.activity
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -17,13 +16,10 @@ import com.bumptech.glide.Glide
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 
-
-
 class BuzzerScreenActivity : GameActivity() {
 
-    private val MAX_N_PLAYERS = 4
-    private val artwork_dim = 200
-    private val NO_BUZZER_PRESSED = -1
+    private val artworkDim = 200
+    private val noBuzzerPressed = -1
     private val buzzersToRows:HashMap<Int, Int> = initHashmap()
     private val rowsIdArray = ArrayList(buzzersToRows.values)
     private val buzIds = ArrayList(buzzersToRows.keys)
@@ -39,7 +35,7 @@ class BuzzerScreenActivity : GameActivity() {
         buzzersToRows.put(R.id.buzzer_3, R.id.row_3)
         return buzzersToRows
     }
-    var pressedBuzzer = NO_BUZZER_PRESSED
+    var pressedBuzzer = noBuzzerPressed
 
     private fun setPressed(id: Int) {
         pressedBuzzer = id
@@ -113,14 +109,13 @@ class BuzzerScreenActivity : GameActivity() {
      * Function to set a new round. It includes reinitializing activity elements,
      * and playing new song for the round.
      */
-    @SuppressLint("SetTextI18n")
     private fun startRound(ctx: Context, gameManager: BuzzerGameManager) {
         gameIsOn = true
         findViewById<LinearLayout>(R.id.answer).visibility=View.INVISIBLE
         val title = gameManager.getCurrentSong().getTrackName()
         val artist = gameManager.getCurrentSong().getArtistName()
         findViewById<TextView>(R.id.songTitle).text= "$title - $artist"
-        Glide.with(ctx).load(gameManager.getCurrentSong().getArtworkUrl()).override(artwork_dim, artwork_dim).into(findViewById(R.id.songArtwork))
+        Glide.with(ctx).load(gameManager.getCurrentSong().getArtworkUrl()).override(artworkDim, artworkDim).into(findViewById(R.id.songArtwork))
         gameManager.playSong()
         checkRunnable()
         barTimer(findViewById(R.id.progressBarBuzzer), ctx, gameManager)
@@ -263,7 +258,7 @@ class BuzzerScreenActivity : GameActivity() {
             if (gameManager.playingMediaPlayer()) {
                 gameManager.stopMediaPlayer()
             }
-            setPressed(NO_BUZZER_PRESSED) // reset the buzzer
+            setPressed(noBuzzerPressed) // reset the buzzer
             gameManager.setNextSong()
             startRound(ctx, gameManager)
         }

--- a/app/src/main/java/ch/sdp/vibester/activity/BuzzerScreenActivity.kt
+++ b/app/src/main/java/ch/sdp/vibester/activity/BuzzerScreenActivity.kt
@@ -1,5 +1,6 @@
 package ch.sdp.vibester.activity
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -7,12 +8,12 @@ import android.view.Gravity
 import android.view.View
 import android.view.Window
 import android.widget.*
-import androidx.appcompat.app.AppCompatActivity
 import ch.sdp.vibester.BuzzerScoreUpdater
 import ch.sdp.vibester.R
 import ch.sdp.vibester.helper.GameManager
 import ch.sdp.vibester.helper.BuzzerGameManager
 import ch.sdp.vibester.model.Song
+import com.bumptech.glide.Glide
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 
@@ -21,6 +22,7 @@ import kotlin.collections.HashMap
 class BuzzerScreenActivity : GameActivity() {
 
     private val MAX_N_PLAYERS = 4
+    private val artwork_dim = 300
     private val NO_BUZZER_PRESSED = -1
     private val buzzersToRows:HashMap<Int, Int> = initHashmap()
     private val rowsIdArray = ArrayList(buzzersToRows.values)
@@ -111,13 +113,16 @@ class BuzzerScreenActivity : GameActivity() {
      * Function to set a new round. It includes reinitializing activity elements,
      * and playing new song for the round.
      */
+    @SuppressLint("SetTextI18n")
     private fun startRound(ctx: Context, gameManager: BuzzerGameManager) {
         gameIsOn = true
         findViewById<LinearLayout>(R.id.answer).visibility=View.INVISIBLE
 
         // fetch song and initialise answerText. We'll see later for the image
         val title = gameManager.getCurrentSong().getTrackName()
-        findViewById<TextView>(R.id.answerText).text=title
+        val artist = gameManager.getCurrentSong().getArtistName()
+        findViewById<TextView>(R.id.songTitle).text= "$title - $artist"
+        Glide.with(ctx).load(gameManager.getCurrentSong().getArtworkUrl()).override(artwork_dim, artwork_dim).into(findViewById(R.id.songArtwork))
         gameManager.playSong()
         checkRunnable()
         barTimer(findViewById(R.id.progressBarBuzzer), ctx, gameManager)

--- a/app/src/main/res/layout/activity_buzzer_screen.xml
+++ b/app/src/main/res/layout/activity_buzzer_screen.xml
@@ -70,10 +70,10 @@
     <LinearLayout
         android:id="@+id/answer"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
         android:layout_marginEnd="30dp"
-        android:background="#AAAAAA"
+        android:background="#DDDDDD"
         android:gravity="center"
         android:orientation="vertical"
         android:visibility="invisible"
@@ -83,10 +83,19 @@
         app:layout_constraintTop_toTopOf="@+id/buzzersLayout">
 
         <TextView
-            android:id="@+id/answerText"
-            android:layout_width="275dp"
+            android:id="@+id/songTitle"
+            android:layout_width="wrap_content"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            android:textStyle="bold"
             android:layout_height="wrap_content"
             android:gravity="center" />
+
+        <ImageView
+            android:id="@+id/songArtwork"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/logo" />
 
         <Button
             android:id="@+id/buttonCorrect"

--- a/app/src/main/res/layout/activity_buzzer_screen.xml
+++ b/app/src/main/res/layout/activity_buzzer_screen.xml
@@ -73,7 +73,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
         android:layout_marginEnd="30dp"
-        android:background="#DDDDDD"
+        android:background="@color/light_grey"
         android:gravity="center"
         android:orientation="vertical"
         android:visibility="invisible"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,5 +25,6 @@
     <color name="maximum_yellow_red">#FFFFCB77</color>
     <color name="floral_white">#FFFEF9EF</color>
     <color name="darker_floral_white">#FFFAE4B7</color>
+    <color name="light_grey">#DDDDDD</color>
     <color name="light_coral">#FFFE6D73</color>
 </resources>


### PR DESCRIPTION
This PR adds, in the local buzzer game, the feature of the guessed song's album artwork being displayed on the answer card alongside the title.
Other minor adjustments were made, such as the artist's name appearing next to the title, and some UI adjustments on the size + color of the answer card.
![pr_artwork1](https://user-images.githubusercontent.com/44404546/167145553-d39b4c4d-7e7a-4b50-86b0-57e7b8e2d70c.png)